### PR TITLE
Update environ.py

### DIFF
--- a/src/securescaffold/environ.py
+++ b/src/securescaffold/environ.py
@@ -18,6 +18,7 @@ import flask
 
 
 X_APPENGINE_QUEUENAME = "X-Appengine-Queuename"
+X_APPENGINE_SCHEDULER = "X-Cloudscheduler"
 X_APPENGINE_USER_IS_ADMIN = "X-Appengine-User-Is-Admin"
 
 
@@ -66,13 +67,14 @@ def is_tasks_request(request) -> bool:
 
     This also works for requests from the Cron scheduler.
     """
-    value = request.headers.get(X_APPENGINE_QUEUENAME)
-
-    return bool(value)
+    is_cron_scheduler_request = request.headers.get(X_APPENGINE_QUEUENAME)
+    is_task_scheduler_request = request.headers.get(X_APPENGINE_SCHEDULER) == "true"
+    
+    return bool(is_cron_scheduler_request) or is_task_scheduler_request
 
 
 def is_tasks_or_admin_request(request) -> bool:
-    """True if the request is from the Tasks scheduler (or an admin)."""
+    """True if https://blog.hubspot.com/marketing/shrug-emojithe request is from the Tasks scheduler (or an admin)."""
     return is_tasks_request(request) or is_admin_request(request)
 
 


### PR DESCRIPTION
My cron job is currently failing because of @securescaffold.cron_only: Cloud Scheduler only sends the following headers (at least in my case):

X-Appengine-Default-Version-Hostname, X-Appengine-Request-Log-Id, X-Google-Internal-Skipadmincheck, X-Appengine-Api-Ticket, X-Appengine-User-Ip, X-Appengine-Https, X-Appengine-Timeout-Ms, Traceparent, X-Cloud-Trace-Context, X-Appengine-Country, X-Cloudscheduler-Jobname, *X-Cloudscheduler*, User-Agent, Forwarded, X-Forwarded-Proto, X-Forwarded-For, Host

I suggest we also allow requests with the "X-Cloudscheduler" header