### PR TITLE
(chore): Fix Python-app example startup

### DIFF
--- a/examples/python-app/main.py
+++ b/examples/python-app/main.py
@@ -34,9 +34,9 @@ def about():
     """
 
     # The Anchors renderer trusts the headers in the Markdown file.
-    with open("README-secure-scaffold.md") as fh:
-        m = mistune.Markdown(renderer=Anchors())
-        readme = m.render(fh.read())
+    with open("README.md") as fh:
+        m = mistune.create_markdown(renderer=Anchors())
+        readme = m(fh.read())
         readme = markupsafe.Markup(readme)
 
     context = {
@@ -75,7 +75,7 @@ def headers():
     return flask.render_template("headers.html", **context)
 
 
-class Anchors(mistune.Renderer):
+class Anchors(mistune.HTMLRenderer):
     """Adds id attributes to <h*> elements.
 
     This is not safe if you cannot trust the Markdown content.

--- a/examples/python-app/requirements.txt
+++ b/examples/python-app/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.1
+Flask==2.1.0
 https://github.com/google/gae-secure-scaffold-python3/archive/master.zip
 google-cloud-ndb
 flask-talisman


### PR DESCRIPTION
This PR fixes 2 problems caused by new versions of dependencies:

**1. ImportError: cannot import name 'escape' from 'jinja2'**
Jinja is a dependency of Flask and Flask V1.X.X uses the escape module from Jinja, however recently support for the escape module was dropped in newer versions of Jinja.

https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0
Reference: https://stackoverflow.com/questions/71718167/importerror-cannot-import-name-escape-from-jinja2

**2. AttributeError: module 'mistune' has no attribute 'Renderer'**
It looks like the current version of Mistune library change some of their public functions.
In order to get the python-app example running I had to update a few things:

- Use mistune.create_markdown instead of mistune.Markdown
- Update Rendered to HTMLRenderer

Reference: https://mistune.readthedocs.io/en/latest/guide.html

@davidwtbuxton @miuraken Please, kindly review the updates.
Thank you.