### PR TITLE
Fix tests to run with nox, and using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,21 @@
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: google-github-actions/setup-gcloud@v0
+        with:
+          install_components: 'cloud-datastore-emulator'
+      - run: |
+          python -m pip install --upgrade pip
+          pip install nox
+      - name: Tests (${{ matrix.python-version }})
+        run: nox --session tests-${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__/
 .nox/
 /dist/
 .mypy_cache/
+.venv/
+/build/

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,10 @@
 import nox
 
 
-@nox.session(python=["3.7", "3.8"])
+nox.options.default_venv_backend = "venv"
+
+
+@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
 def tests(session):
     session.install("pytest")
     session.install(".")

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,7 @@ setuptools.setup(
         "Framework :: Flask",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3",
         "Topic :: Internet",
     ],
 )

--- a/src/securescaffold/tests/test_factory.py
+++ b/src/securescaffold/tests/test_factory.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 from unittest import mock
 
 import pytest
@@ -68,7 +67,7 @@ def test_create_app_adds_csp_headers(ndb_client):
         " 'self' www.google.com www.youtube.com; script-src 'self'"
         " ajax.googleapis.com *.googleanalytics.com *.google-analytics.com;"
         " style-src 'self' ajax.googleapis.com fonts.googleapis.com"
-        " *.gstatic.com; default-src 'self' *.gstatic.com"
+        " *.gstatic.com; object-src 'none'; default-src 'self' *.gstatic.com"
     )
     assert resp.headers["Content-Security-Policy"] == expected
 

--- a/src/securescaffold/tests/test_views.py
+++ b/src/securescaffold/tests/test_views.py
@@ -54,8 +54,7 @@ class RedirectTestCase(unittest.TestCase):
                 response = client.get("/", headers=headers)
 
                 self.assertEqual(response.status_code, 302)
-                _, _, path = response.location.partition("http://localhost")
-                self.assertEqual(path, expected)
+                self.assertEqual(response.location, expected)
 
     def test_default_config_locales(self):
         with self.assertRaises(KeyError):
@@ -65,7 +64,7 @@ class RedirectTestCase(unittest.TestCase):
         response = client.get("/")
 
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.location, "http://localhost/intl/en/")
+        self.assertEqual(response.location, "/intl/en/")
 
     def test_default_config_locales_redirect_to(self):
         with self.assertRaises(KeyError):
@@ -75,4 +74,4 @@ class RedirectTestCase(unittest.TestCase):
         response = client.get("/")
 
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.location, "http://localhost/intl/en/")
+        self.assertEqual(response.location, "/intl/en/")


### PR DESCRIPTION
The --python=3.7 tests fail for me with errors installing the dependencies, but this may be a Mac M1 thing since the 3.7 tests pass when running on GitHub Actions.