### PR TITLE
Fix compatibility with Flask 3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,8 +18,10 @@ import nox
 nox.options.default_venv_backend = "venv"
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
-def tests(session):
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
+@nox.parametrize("flask", ["2", "3"])
+def tests(session, flask):
     session.install("pytest")
+    session.install(f"flask~={flask}.0")
     session.install(".")
     session.run("pytest", "--disable-warnings")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask
+Flask>=2.0
 flask-talisman
-flask-seasurf
+flask-seasurf @ https://github.com/maxcountryman/flask-seasurf/archive/f383b482c69e0b0e8064a8eb89305cea3826a7b6.zip
 google-cloud-ndb

--- a/src/securescaffold/tests/test_factory.py
+++ b/src/securescaffold/tests/test_factory.py
@@ -81,7 +81,7 @@ def test_create_app_adds_other_security_headers(ndb_client):
     assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
     assert response.headers["X-Content-Type-Options"] == "nosniff"
     assert response.headers["X-Frame-Options"] == "SAMEORIGIN"
-    assert response.headers["X-Xss-Protection"] == "1; mode=block"
+    assert "X-Xss-Protection" not in response.headers
 
 
 def test_extra_flask_args(ndb_client):


### PR DESCRIPTION
- Require Flask 2.x or later.
- Pin Flask-Seasurf to GitHub commit.
- Add Python 3.11, remove 3.7 from test matrix.
- Fix headers test for latest Flask-Talisman changes.

Fixes #21 